### PR TITLE
feat: support beta version

### DIFF
--- a/internal/lsremote.go
+++ b/internal/lsremote.go
@@ -39,6 +39,16 @@ func (g goversion) Minor() int {
 		return i
 	}
 
+	if strings.Contains(vs[1], "beta") {
+		p := strings.SplitN(vs[1], "beta", 2)
+		i, err := strconv.Atoi(p[0])
+		if err != nil {
+			log.Panic(err)
+		}
+
+		return i
+	}
+
 	i, err := strconv.Atoi(vs[1])
 	if err != nil {
 		log.Panic(err)
@@ -58,6 +68,18 @@ func (g goversion) RCVersion() int {
 		log.Panic(err)
 	}
 
+	return i
+}
+
+func (g goversion) BetaVersion() int {
+	vs := strings.SplitN(string(g), "beta", 2)
+	if len(vs) == 1 {
+		return 1000
+	}
+	i, err := strconv.Atoi(vs[1])
+	if err != nil {
+		log.Panic(err)
+	}
 	return i
 }
 
@@ -157,6 +179,10 @@ func sortVersions(versions []goversion) []goversion {
 	sort.Slice(versions, func(i, j int) bool {
 		if versions[i].Minor() != versions[j].Minor() {
 			return versions[i].Minor() < versions[j].Minor()
+		}
+
+		if versions[i].BetaVersion() != versions[j].BetaVersion() {
+			return versions[i].BetaVersion() < versions[j].BetaVersion()
 		}
 
 		if versions[i].RCVersion() != versions[j].RCVersion() {

--- a/internal/lsremote_test.go
+++ b/internal/lsremote_test.go
@@ -28,9 +28,14 @@ func Test_sortVersions(t *testing.T) {
 			expect: []goversion{"1.13rc1", "1.13", "1.13.1"},
 		},
 		{
+			name:   "with beta",
+			in:     []goversion{"1.13beta1", "1.13.1", "1.13"},
+			expect: []goversion{"1.13beta1", "1.13", "1.13.1"},
+		},
+		{
 			name:   "complex case",
-			in:     []goversion{"1.13rc1", "1.13.1", "1.13", "1.1", "1.14rc1", "1.13rc2"},
-			expect: []goversion{"1.1", "1.13rc1", "1.13rc2", "1.13", "1.13.1", "1.14rc1"},
+			in:     []goversion{"1.13rc1", "1.13beta1", "1.13.1", "1.13", "1.1", "1.14rc1", "1.13rc2"},
+			expect: []goversion{"1.1", "1.13beta1", "1.13rc1", "1.13rc2", "1.13", "1.13.1", "1.14rc1"},
 		},
 	}
 


### PR DESCRIPTION
It crashed when I used goswitch ls-remote.

```
goswitch ls-remote
2020/06/12 07:22:10 strconv.Atoi: parsing "15beta1": invalid syntax
panic: strconv.Atoi: parsing "15beta1": invalid syntax

goroutine 1 [running]:
log.Panic(0xc0001878c0, 0x1, 0x1)
	/usr/local/Cellar/go/1.14.3/libexec/src/log/log.go:351 +0xac
github.com/akito0107/goswitch/internal.goversion.Minor(0xc000099790, 0xb, 0xa)
	/Users/orisano/go/src/github.com/akito0107/goswitch/internal/lsremote.go:44 +0x1fa
github.com/akito0107/goswitch/internal.sortVersions.func1(0x0, 0x4, 0x0)
	/Users/orisano/go/src/github.com/akito0107/goswitch/internal/lsremote.go:158 +0xa1
sort.doPivot_func(0xc000ae3a88, 0xc00000fec0, 0x0, 0xcc, 0x18, 0xc00000fea0)
	/usr/local/Cellar/go/1.14.3/libexec/src/sort/zfuncversion.go:87 +0x44c
sort.quickSort_func(0xc000ae3a88, 0xc00000fec0, 0x0, 0xcc, 0x10)
	/usr/local/Cellar/go/1.14.3/libexec/src/sort/zfuncversion.go:143 +0x9a
sort.Slice(0x13db760, 0xc00000fea0, 0xc000187a88)
	/usr/local/Cellar/go/1.14.3/libexec/src/sort/slice.go:17 +0xf1
github.com/akito0107/goswitch/internal.sortVersions(0xc000112000, 0xcc, 0x100, 0x0, 0x0, 0xc00017a0e0)
	/Users/orisano/go/src/github.com/akito0107/goswitch/internal/lsremote.go:157 +0x9e
github.com/akito0107/goswitch/internal.LSRemote(0x1512d80, 0xc0000280c0, 0x0, 0x0)
	/Users/orisano/go/src/github.com/akito0107/goswitch/internal/lsremote.go:115 +0x332
main.main.func2(0xc000030900, 0x1, 0x1)
	/Users/orisano/go/src/github.com/akito0107/goswitch/main.go:28 +0x37
github.com/urfave/cli.(*Command).Run(0xc00011c7e0, 0xc000030840, 0x0, 0x0)
	/Users/orisano/go/src/github.com/urfave/cli/command.go:163 +0x4e0
github.com/urfave/cli.(*App).RunContext(0xc000001b00, 0x1512d80, 0xc0000280c0, 0xc00000e0a0, 0x2, 0x2, 0x0, 0x0)
	/Users/orisano/go/src/github.com/urfave/cli/app.go:306 +0x814
github.com/urfave/cli.(*App).Run(...)
	/Users/orisano/go/src/github.com/urfave/cli/app.go:217
main.main()
	/Users/orisano/go/src/github.com/akito0107/goswitch/main.go:34 +0x1a3
```

go1.15beta1 was released today.
currently,  goswitch does not support beta version. I implemented it.
