### PR TITLE
fix: support patch with rc

### DIFF
--- a/internal/lsremote.go
+++ b/internal/lsremote.go
@@ -89,11 +89,11 @@ const initialPage = 4
 const perPage = 30 // max
 
 func LSRemoteGH(c context.Context) error {
-    client := github.NewClient(nil)
+	client := github.NewClient(nil)
 
-    var versions []goversion
-    page := initialPage
-    for {
+	var versions []goversion
+	page := initialPage
+	for {
 		tags, next, err := fetchNextTags(c, client, page)
 		if err != nil {
 			return fmt.Errorf("fetchTags failed: %w", err)
@@ -108,12 +108,12 @@ func LSRemoteGH(c context.Context) error {
 	versions = sortVersions(versions)
 	printVersions(versions)
 
-    return nil
+	return nil
 }
 
 func fetchNextTags(c context.Context, client *github.Client, nextPage int) ([]goversion, int, error) {
 	tags, resp, err := client.Repositories.ListTags(c, "golang", "go", &github.ListOptions{
-		Page: nextPage,
+		Page:    nextPage,
 		PerPage: perPage,
 	})
 	if err != nil {

--- a/internal/lsremote.go
+++ b/internal/lsremote.go
@@ -29,32 +29,10 @@ func (g goversion) Minor() int {
 	if len(vs) == 1 {
 		return 0
 	}
-
-	if strings.Contains(vs[1], "rc") {
-		p := strings.SplitN(vs[1], "rc", 2)
-		i, err := strconv.Atoi(p[0])
-		if err != nil {
-			log.Panic(err)
-		}
-
-		return i
-	}
-
-	if strings.Contains(vs[1], "beta") {
-		p := strings.SplitN(vs[1], "beta", 2)
-		i, err := strconv.Atoi(p[0])
-		if err != nil {
-			log.Panic(err)
-		}
-
-		return i
-	}
-
-	i, err := strconv.Atoi(vs[1])
+	i, err := strconv.Atoi(trimExtra(vs[1]))
 	if err != nil {
 		log.Panic(err)
 	}
-
 	return i
 }
 
@@ -89,11 +67,22 @@ func (g goversion) Patch() int {
 	if len(vs) != 3 {
 		return 0
 	}
-	i, err := strconv.Atoi(vs[2])
+	i, err := strconv.Atoi(trimExtra(vs[2]))
 	if err != nil {
 		log.Panic(err)
 	}
 	return i
+}
+
+func trimExtra(v string) string {
+	extras := []string{"beta", "rc"}
+	for _, extra := range extras {
+		index := strings.Index(v, extra)
+		if index >= 0 {
+			return v[:index]
+		}
+	}
+	return v
 }
 
 const initialPage = 4
@@ -192,16 +181,13 @@ func sortVersions(versions []goversion) []goversion {
 		if versions[i].Minor() != versions[j].Minor() {
 			return versions[i].Minor() < versions[j].Minor()
 		}
-
+		if versions[i].Patch() != versions[j].Patch() {
+			return versions[i].Patch() < versions[j].Patch()
+		}
 		if versions[i].BetaVersion() != versions[j].BetaVersion() {
 			return versions[i].BetaVersion() < versions[j].BetaVersion()
 		}
-
-		if versions[i].RCVersion() != versions[j].RCVersion() {
-			return versions[i].RCVersion() < versions[j].RCVersion()
-		}
-
-		return versions[i].Patch() < versions[j].Patch()
+		return versions[i].RCVersion() < versions[j].RCVersion()
 	})
 
 	return versions

--- a/internal/lsremote_test.go
+++ b/internal/lsremote_test.go
@@ -37,6 +37,11 @@ func Test_sortVersions(t *testing.T) {
 			in:     []goversion{"1.13rc1", "1.13beta1", "1.13.1", "1.13", "1.1", "1.14rc1", "1.13rc2"},
 			expect: []goversion{"1.1", "1.13beta1", "1.13rc1", "1.13rc2", "1.13", "1.13.1", "1.14rc1"},
 		},
+		{
+			name:   "patch with rc",
+			in:     []goversion{"go1.9", "go1.9.2", "go1.9.2rc2"},
+			expect: []goversion{"go1.9", "go1.9.2rc2", "go1.9.2"},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
I encountered the below problem.
```
2021/04/10 10:45:00 strconv.Atoi: parsing "2rc2": invalid syntax
panic: strconv.Atoi: parsing "2rc2": invalid syntax

goroutine 1 [running]:
log.Panic(0xc0001897a0, 0x1, 0x1)
	/Users/orisano/sdk/go1.16.1/src/log/log.go:354 +0xae
github.com/akito0107/goswitch/internal.goversion.Patch(0xc000427400, 0xa, 0x2)
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/internal/lsremote.go:93 +0xe5
github.com/akito0107/goswitch/internal.sortVersions.func1(0x7c, 0x83, 0xc000189801)
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/internal/lsremote.go:192 +0x3c5
sort.medianOfThree_func(0xc000e7ba90, 0xc0004a9040, 0x7c, 0x83, 0x8a)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:58 +0xb1
sort.doPivot_func(0xc000e7ba90, 0xc0004a9040, 0x7c, 0x8b, 0xe, 0x7c)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:80 +0x88
sort.quickSort_func(0xc000e7ba90, 0xc0004a9040, 0x7c, 0x8b, 0xe)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:143 +0x97
sort.quickSort_func(0xc000e7ba90, 0xc0004a9040, 0x4c, 0x8b, 0xf)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:148 +0x131
sort.quickSort_func(0xc000e7ba90, 0xc0004a9040, 0x0, 0x8b, 0x10)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:148 +0x131
sort.quickSort_func(0xc000e7ba90, 0xc0004a9040, 0x0, 0x170, 0x11)
	/Users/orisano/sdk/go1.16.1/src/sort/zfuncversion.go:145 +0xf5
sort.Slice(0x1372bc0, 0xc0002a4138, 0xc000189a90)
	/Users/orisano/sdk/go1.16.1/src/sort/slice.go:20 +0xe8
github.com/akito0107/goswitch/internal.sortVersions(0xc000e50000, 0x170, 0x200, 0x0, 0x0, 0xc00043d1f0)
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/internal/lsremote.go:179 +0xa5
github.com/akito0107/goswitch/internal.LSRemote(0x146dab0, 0xc00001c0b8, 0x0, 0x0)
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/internal/lsremote.go:137 +0x32d
main.main.func2(0xc000026780, 0x1, 0x1)
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/main.go:28 +0x37
github.com/urfave/cli/v2.(*Command).Run(0xc0001947e0, 0xc0000266c0, 0x0, 0x0)
	/Users/orisano/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x4dd
github.com/urfave/cli/v2.(*App).RunContext(0xc0000791e0, 0x146dab0, 0xc00001c0b8, 0xc000012040, 0x2, 0x2, 0x0, 0x0)
	/Users/orisano/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0x810
github.com/urfave/cli/v2.(*App).Run(...)
	/Users/orisano/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
	/Users/orisano/go/pkg/mod/github.com/akito0107/goswitch@v1.1.0/main.go:34 +0x1a5
```

The root cause is response including patch with rc version from golang.org/dl. (ex. go1.9.2rc2)
I fixed it.